### PR TITLE
Change library name.

### DIFF
--- a/Project/Wikode/requirements.txt
+++ b/Project/Wikode/requirements.txt
@@ -14,6 +14,6 @@ six==1.16.0
 Wikidata==0.7.0
 wincertstore==0.2
 xmltodict==0.12.0
-psycopg2==2.8.6
+psycopg2-binary==2.8.6
 requests==2.25.1
 coverage==5.5


### PR DESCRIPTION
requirements.txt yuklerken psycopg2 hata veriyordu. Asagidaki linkteki cozumu denedim ve oldu.
Library'nin ismini "psycopg2-binary" olarak degistirince yuklendi. Proje ayaga kalkti.

https://stackoverflow.com/questions/49811955/unable-to-install-psycopg2-pip-install-psycopg2